### PR TITLE
show submenu conditionally; remove conditional CSS

### DIFF
--- a/src/components/layout/Navigation/NavigationMenu.tsx
+++ b/src/components/layout/Navigation/NavigationMenu.tsx
@@ -20,19 +20,10 @@ interface ToggleableProps {
 const ToggleMenu = styled('ul')<ToggleableProps>`
   list-style-type: none;
   margin: 0;
-  padding: 0;
-  opacity: 0;
   background: white;
-  padding: 0;
-  ${p =>
-    p.isOpen &&
-    css`
-      opacity: 1;
-      transform: scale3d(1, 1, 1);
-      border-top: 1px solid ${colors.grey02};
-      border-bottom: 1px solid ${colors.grey02};
-      padding: 8px 0;
-    `};
+  border-top: 1px solid ${colors.grey02};
+  border-bottom: 1px solid ${colors.grey02};
+  padding: 8px 0;
 `
 
 const ToggleMenuList = styled('li')`
@@ -150,16 +141,17 @@ const NavigationMenu: React.FC<NavigationMenuProps> = ({ node, isOpen, setIsOpen
         </Heading>
         <RightArrowIcon />
       </MenuToggle>
-      <ToggleMenu isOpen={isOpen}>
-        {isOpen &&
-          node.items.map(item => (
+      {isOpen && (
+        <ToggleMenu>
+          {node.items.map(item => (
             <ToggleMenuList key={item.id}>
               <Link to={item.slug} getProps={isActive}>
                 {item.title}
               </Link>
             </ToggleMenuList>
           ))}
-      </ToggleMenu>
+        </ToggleMenu>
+      )}
     </NavGroup>
   )
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15221702/66679625-a14ece00-ec3c-11e9-982f-e635b38b6c88.png)

on the prod site I'm seeing some weird behavior with the submenus in the docs navigation. This change should resolve that by removing the conditional CSS and instead conditionally rendering the entire submenu based on the value of `isOpen`