### PR TITLE
content: add tip about lerna, fix link

### DIFF
--- a/content/docs/contributing/setting-up.md
+++ b/content/docs/contributing/setting-up.md
@@ -12,6 +12,7 @@ To get started:
 ```bash
 git clone git@github.com:tinacms/tinacms.git
 cd tinacms
+npm install
 npm run bootstrap
 npm run build
 
@@ -20,9 +21,11 @@ cd packages/demo-gatsby
 npm run start
 ```
 
+<tip>**TinaCMS** uses [**Lerna**](https://lerna.js.org/) to manage dependencies when developing locally. This allows the various packages to reference each other via symlinks. Running `npm install` from within a package replaces the symlinks with references to the packages in the npm registry.</tip>
+
 ## Commands
 
-| Commands                           | Description                                  |
+| Commands                           | Description                                   |
 | ---------------------------------- | --------------------------------------------- |
 | npm run bootstrap                  | Install dependencies and link local packages. |
 | npm run build                      | Build all packages                            |

--- a/content/docs/gatsby/manual-setup.md
+++ b/content/docs/gatsby/manual-setup.md
@@ -7,7 +7,7 @@ next: /docs/gatsby/markdown
 
 Learn how to setup Tina on an existing Gatsby site.
 
-After this guide you will have installed and added the TinaCMS sidebar to your project. However, this won't make your content editable. Go to the [next guide](/docs/gatsby/edit-content) to learn how to make content editable.
+After this guide you will have installed and added the TinaCMS sidebar to your project. However, this won't make your content editable. Go to the [next guide](/docs/gatsby/markdown) to learn how to make content editable.
 
 Assumptions: This guide assumes you have the Gatsby CLI installed, Node & a package manager.
 


### PR DESCRIPTION
- Add `npm install` command to getting started guide for development
- Add tip about using Lerna and not running `npm install` on internal packages
- Fix 404 in docs