### PR TITLE
Update Link Path for Registering Fields in Gatsby

### DIFF
--- a/content/docs/fields/custom-fields.md
+++ b/content/docs/fields/custom-fields.md
@@ -79,4 +79,4 @@ cms.forms.addFieldPlugin({
 
 ## Further Reading
 
-- [Registering Fields in Gatsby](/gatsby/custom-fields)
+- [Registering Fields in Gatsby](/docs/gatsby/custom-fields)


### PR DESCRIPTION
The current link (/gatsby/custom-fields) is returning a 404. It looks like this one should probably point to /docs/gatsby/custom-fields. The link is on line 82 in custom-fields.md.