### PR TITLE
Fix typo on toggle.md

### DIFF
--- a/content/docs/fields/toggle.md
+++ b/content/docs/fields/toggle.md
@@ -28,7 +28,7 @@ const BlogPostForm = {
 
  - `name`: The path to some value in the data being edited.
  - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
- - `label`: An human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+ - `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
  - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
 ```typescript


### PR DESCRIPTION
Fix for typo on line 31 of toggle.md. Change "An human readable label" to "A human readable label"