### PR TITLE
Fix Label Description Typo in Field Docs

### DIFF
--- a/content/docs/fields/color.md
+++ b/content/docs/fields/color.md
@@ -6,7 +6,6 @@ next: /docs/fields/toggle
 
 The `color` field is a visual color picker. This field is used for content values that handle the rendering of color. Can be saved as RGB or hex value.
 
-
 ## Definition
 
 Below is an example of how a `color` field could be defined in a Gatsby remark form. Read more on passing in form field options [here](/docs/gatsby/markdown#customizing-remark-forms).
@@ -19,7 +18,7 @@ const BlogPostForm = {
       component: 'color',
       label: 'Background Color',
       description: 'Edit the page background color here',
-      colorFormat: 'hex'
+      colorFormat: 'hex',
     },
     // ...
   ],
@@ -28,11 +27,11 @@ const BlogPostForm = {
 
 ## Options
 
- - `name`: The path to some value in the data being edited.
- - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
- - `label`: An human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
- - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
- -  `colorFormat`: Optionally specify whether you want the color value to be a hexadecimal ('hex') or RBG value.
+- `name`: The path to some value in the data being edited.
+- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+- `colorFormat`: Optionally specify whether you want the color value to be a hexadecimal ('hex') or RBG value.
 
 ```typescript
 interface ColorConfig {

--- a/content/docs/fields/color.md
+++ b/content/docs/fields/color.md
@@ -6,6 +6,7 @@ next: /docs/fields/toggle
 
 The `color` field is a visual color picker. This field is used for content values that handle the rendering of color. Can be saved as RGB or hex value.
 
+
 ## Definition
 
 Below is an example of how a `color` field could be defined in a Gatsby remark form. Read more on passing in form field options [here](/docs/gatsby/markdown#customizing-remark-forms).
@@ -18,7 +19,7 @@ const BlogPostForm = {
       component: 'color',
       label: 'Background Color',
       description: 'Edit the page background color here',
-      colorFormat: 'hex',
+      colorFormat: 'hex'
     },
     // ...
   ],
@@ -27,11 +28,11 @@ const BlogPostForm = {
 
 ## Options
 
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
-- `colorFormat`: Optionally specify whether you want the color value to be a hexadecimal ('hex') or RBG value.
+ - `name`: The path to some value in the data being edited.
+ - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+ - `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+ - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+ -  `colorFormat`: Optionally specify whether you want the color value to be a hexadecimal ('hex') or RBG value.
 
 ```typescript
 interface ColorConfig {

--- a/content/docs/fields/date.md
+++ b/content/docs/fields/date.md
@@ -13,17 +13,18 @@ Below is an example of how a `date` field could be defined in a Gatsby remark fo
 ```javascript
 const BlogPostForm = {
   fields: [
-   {
+    {
       label: 'Date',
       name: 'rawFrontmatter.date',
       component: 'date',
-      dateFormat: "MMMM DD YYYY",
-      timeFormat: false
+      dateFormat: 'MMMM DD YYYY',
+      timeFormat: false,
     },
     // ...
   ],
 }
 ```
+
 ## Options
 
 This field plugin uses [`react-datettime`](https://www.npmjs.com/package/react-datetime) under the hood.
@@ -38,13 +39,14 @@ interface DateConfig extends DatetimepickerProps {
   timeFormat?: boolean | string // Moment date format
 }
 ```
+
 #### Tina Options
 
- - `name`: The path to some value in the data being edited.
- - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
- - `label`: An human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
- - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+- `name`: The path to some value in the data being edited.
+- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
- #### Additional Options
+#### Additional Options
 
 Any extra properties added to the the `date` field definition will be passed along to the [`react-datettime`](https://www.npmjs.com/package/react-datetime) component. [Moment.js](https://momentjs.com/docs/#/displaying/format/) format is used. See the full list of options [here](https://www.npmjs.com/package/react-datetime#api).

--- a/content/docs/fields/date.md
+++ b/content/docs/fields/date.md
@@ -13,18 +13,17 @@ Below is an example of how a `date` field could be defined in a Gatsby remark fo
 ```javascript
 const BlogPostForm = {
   fields: [
-    {
+   {
       label: 'Date',
       name: 'rawFrontmatter.date',
       component: 'date',
-      dateFormat: 'MMMM DD YYYY',
-      timeFormat: false,
+      dateFormat: "MMMM DD YYYY",
+      timeFormat: false
     },
     // ...
   ],
 }
 ```
-
 ## Options
 
 This field plugin uses [`react-datettime`](https://www.npmjs.com/package/react-datetime) under the hood.
@@ -39,14 +38,13 @@ interface DateConfig extends DatetimepickerProps {
   timeFormat?: boolean | string // Moment date format
 }
 ```
-
 #### Tina Options
 
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+ - `name`: The path to some value in the data being edited.
+ - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+ - `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+ - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
-#### Additional Options
+ #### Additional Options
 
 Any extra properties added to the the `date` field definition will be passed along to the [`react-datettime`](https://www.npmjs.com/package/react-datetime) component. [Moment.js](https://momentjs.com/docs/#/displaying/format/) format is used. See the full list of options [here](https://www.npmjs.com/package/react-datetime#api).

--- a/content/docs/fields/image.md
+++ b/content/docs/fields/image.md
@@ -52,13 +52,13 @@ const BlogPostForm = {
 
 ## Options
 
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
-- `parse`: Defines how the actual frontmatter or data value gets populated. The name of the file gets passed as an argument, and one can set the path this image as defined by the uploadDir property.
-- `previewSrc`: Defines the path for the src attribute on the image preview. If using gatsby-image, the path to the `childImageSharp.fluid.src` needs to be provided.
-- `uploadDir`: Defines the upload directory for the image. All of the post data is passed in, `fileRelativePath` is most useful in defining the upload directory, but you can also statically define the upload directory.
+ - `name`: The path to some value in the data being edited.
+ - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+ - `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+ - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+ - `parse`: Defines how the actual frontmatter or data value gets populated. The name of the file gets passed as an argument, and one can set the path this image as defined by the uploadDir property.
+ - `previewSrc`: Defines the path for the src attribute on the image preview. If using gatsby-image, the path to the `childImageSharp.fluid.src` needs to be provided.
+ - `uploadDir`: Defines the upload directory for the image. All of the post data is passed in, `fileRelativePath` is most useful in defining the upload directory, but you can also statically define the upload directory.
 
 ```typescript
 interface ImageConfig {

--- a/content/docs/fields/image.md
+++ b/content/docs/fields/image.md
@@ -52,13 +52,13 @@ const BlogPostForm = {
 
 ## Options
 
- - `name`: The path to some value in the data being edited.
- - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
- - `label`: An human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
- - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
- - `parse`: Defines how the actual frontmatter or data value gets populated. The name of the file gets passed as an argument, and one can set the path this image as defined by the uploadDir property.
- - `previewSrc`: Defines the path for the src attribute on the image preview. If using gatsby-image, the path to the `childImageSharp.fluid.src` needs to be provided.
- - `uploadDir`: Defines the upload directory for the image. All of the post data is passed in, `fileRelativePath` is most useful in defining the upload directory, but you can also statically define the upload directory.
+- `name`: The path to some value in the data being edited.
+- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+- `parse`: Defines how the actual frontmatter or data value gets populated. The name of the file gets passed as an argument, and one can set the path this image as defined by the uploadDir property.
+- `previewSrc`: Defines the path for the src attribute on the image preview. If using gatsby-image, the path to the `childImageSharp.fluid.src` needs to be provided.
+- `uploadDir`: Defines the upload directory for the image. All of the post data is passed in, `fileRelativePath` is most useful in defining the upload directory, but you can also statically define the upload directory.
 
 ```typescript
 interface ImageConfig {

--- a/content/docs/fields/markdown.md
+++ b/content/docs/fields/markdown.md
@@ -26,10 +26,10 @@ const BlogPostForm = {
 
 ## Options
 
- - `name`: The path to some value in the data being edited.
- - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
- - `label`: An human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
- - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+- `name`: The path to some value in the data being edited.
+- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
 ```typescript
 interface MarkdownConfig {

--- a/content/docs/fields/markdown.md
+++ b/content/docs/fields/markdown.md
@@ -26,10 +26,10 @@ const BlogPostForm = {
 
 ## Options
 
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+ - `name`: The path to some value in the data being edited.
+ - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+ - `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+ - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
 ```typescript
 interface MarkdownConfig {

--- a/content/docs/fields/text.md
+++ b/content/docs/fields/text.md
@@ -25,10 +25,10 @@ const BlogPostForm = {
 
 ## Options
 
- - `name`: The path to some value in the data being edited.
- - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
- - `label`: An human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
- - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+- `name`: The path to some value in the data being edited.
+- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
 ```typescript
 interface TextConfig {

--- a/content/docs/fields/text.md
+++ b/content/docs/fields/text.md
@@ -25,10 +25,10 @@ const BlogPostForm = {
 
 ## Options
 
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+ - `name`: The path to some value in the data being edited.
+ - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+ - `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+ - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
 ```typescript
 interface TextConfig {

--- a/content/docs/fields/textarea.md
+++ b/content/docs/fields/textarea.md
@@ -6,7 +6,6 @@ next: /docs/fields/markdown
 
 The `textarea` field represents a multi-line text input. It should be used for content values that are long strings: for example, a page description.
 
-
 ## Definition
 
 Below is an example of how a `textarea` field could be defined in a Gatsby remark form. Read more on passing in form field options [here](/docs/gatsby/markdown#customizing-remark-forms).
@@ -27,10 +26,10 @@ const BlogPostForm = {
 
 ## Options
 
- - `name`: The path to some value in the data being edited.
- - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
- - `label`: An human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
- - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+- `name`: The path to some value in the data being edited.
+- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
 ```typescript
 interface TextareaConfig {

--- a/content/docs/fields/textarea.md
+++ b/content/docs/fields/textarea.md
@@ -6,6 +6,7 @@ next: /docs/fields/markdown
 
 The `textarea` field represents a multi-line text input. It should be used for content values that are long strings: for example, a page description.
 
+
 ## Definition
 
 Below is an example of how a `textarea` field could be defined in a Gatsby remark form. Read more on passing in form field options [here](/docs/gatsby/markdown#customizing-remark-forms).
@@ -26,10 +27,10 @@ const BlogPostForm = {
 
 ## Options
 
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+ - `name`: The path to some value in the data being edited.
+ - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+ - `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+ - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
 ```typescript
 interface TextareaConfig {

--- a/content/docs/fields/toggle.md
+++ b/content/docs/fields/toggle.md
@@ -26,10 +26,10 @@ const BlogPostForm = {
 
 ## Options
 
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+ - `name`: The path to some value in the data being edited.
+ - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+ - `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+ - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
 ```typescript
 interface ToggleConfig {

--- a/content/docs/fields/toggle.md
+++ b/content/docs/fields/toggle.md
@@ -26,10 +26,10 @@ const BlogPostForm = {
 
 ## Options
 
- - `name`: The path to some value in the data being edited.
- - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
- - `label`: An human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
- - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+- `name`: The path to some value in the data being edited.
+- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
 ```typescript
 interface ToggleConfig {


### PR DESCRIPTION
Change all occurrences of "An human" to "A human" in content/docs/fields