### PR TITLE
Use npm script to run gatsby develop

### DIFF
--- a/content/docs/gatsby/quickstart.md
+++ b/content/docs/gatsby/quickstart.md
@@ -41,7 +41,7 @@ Now let's start the development server to see how Tina edits our files.
 
 ```
 cd my-tina-starter
-gatsby develop
+npm run develop
 ```
 
 Now navigate to http://localhost:8000 to checkout the starter site!


### PR DESCRIPTION
Thought it would be nice to use the script in package.json to run the site instead of relying on global gatsby cli.