### PR TITLE
Add import to image field snippet

### DIFF
--- a/content/docs/fields/image.md
+++ b/content/docs/fields/image.md
@@ -4,13 +4,15 @@ prev: /docs/fields/date
 next: /docs/fields/color
 ---
 
-The `image` field is a visual color picker. This field is used for content values that point to an image used on the page. This field allows you to upload new images by via dragging or selection in Finder. Note this field does not handle any images included in the markdown body, those would be handled by the [markdown](docs/fields/markdown)component.
+The `image` field is used for content values that point to an image used on the page. This field allows you to upload new images by via dragging or selection in Finder. Note this field does not handle any images included in the markdown body, those would be handled by the [markdown](docs/fields/markdown)component.
 
 ## Definition
 
 Below is an example of how a `image` field could be defined in a Gatsby remark form. Read more on passing in form field options [here](/docs/gatsby/markdown#customizing-remark-forms).
 
 ```javascript
+import get from "lodash.get";
+
 const BlogPostForm = {
   fields: [
     {
@@ -52,13 +54,13 @@ const BlogPostForm = {
 
 ## Options
 
- - `name`: The path to some value in the data being edited.
- - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
- - `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
- - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
- - `parse`: Defines how the actual frontmatter or data value gets populated. The name of the file gets passed as an argument, and one can set the path this image as defined by the uploadDir property.
- - `previewSrc`: Defines the path for the src attribute on the image preview. If using gatsby-image, the path to the `childImageSharp.fluid.src` needs to be provided.
- - `uploadDir`: Defines the upload directory for the image. All of the post data is passed in, `fileRelativePath` is most useful in defining the upload directory, but you can also statically define the upload directory.
+- `name`: The path to some value in the data being edited.
+- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+- `parse`: Defines how the actual frontmatter or data value gets populated. The name of the file gets passed as an argument, and one can set the path this image as defined by the uploadDir property.
+- `previewSrc`: Defines the path for the src attribute on the image preview. If using gatsby-image, the path to the `childImageSharp.fluid.src` needs to be provided.
+- `uploadDir`: Defines the upload directory for the image. All of the post data is passed in, `fileRelativePath` is most useful in defining the upload directory, but you can also statically define the upload directory.
 
 ```typescript
 interface ImageConfig {


### PR DESCRIPTION
When setting up the image field the first time, I ran into some problem that the `get` method was not defined.

Also, I removed some C&P text. 