### PR TITLE
Add consumers API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 # =========================
+# Project-Specific Ignores
+# =========================
+
+# Static file generated during build process
+static/consumers.json
+
+# =========================
 # Node.js-Specific Ignores
 # =========================
 

--- a/content/docs/gatsby/configure-git-plugin.md
+++ b/content/docs/gatsby/configure-git-plugin.md
@@ -3,6 +3,11 @@ title: Configure Git plugin
 id: /docs/gatsby/configure-git-plugin
 prev: /docs/gatsby/json
 next: /docs/gatsby/custom-fields
+consumes:
+  - file: /packages/@tinacms/api-git/src/router.ts
+    details: Describes GitRouterConfig interface
+  - file: /packages/gatsby-tinacms-git/gatsby-node.ts
+    details: Expects gatsby-tinacms-git to pass options directly to git router
 ---
 
 The Git plugin provides some options that can be adjusted.

--- a/static/consumers.json
+++ b/static/consumers.json
@@ -1,0 +1,1 @@
+{"/content/docs/gatsby/configure-git-plugin.md":[{"file":"/packages/@tinacms/api-git/src/router.ts","details":"Describes GitRouterConfig interface"},{"file":"/packages/gatsby-tinacms-git/gatsby-node.ts","details":"Expects gatsby-tinacms-git to pass options directly to git router"}]}

--- a/static/consumers.json
+++ b/static/consumers.json
@@ -1,1 +1,0 @@
-{"/content/docs/gatsby/configure-git-plugin.md":[{"file":"/packages/@tinacms/api-git/src/router.ts","details":"Describes GitRouterConfig interface"},{"file":"/packages/gatsby-tinacms-git/gatsby-node.ts","details":"Expects gatsby-tinacms-git to pass options directly to git router"}]}


### PR DESCRIPTION
This adds a read-only JSON API at `tinacms.org/consumers.json` to assist our documentation maintenance CI task.

Any doc or blog post can identify its dependencies by adding a front matter array with a key of `consumes`. This should be an array of objects (list of dicts) each containing the relative path to a `file` in tinacms/tinacms and, optionally, a `details` string to briefly describe how the doc depends on that file.

The goal is to identify potential cases of documentation drift so they can be addressed promptly. We anticipate false positives to be likely, hence the use of the `details` field to identify at-a-glance when documentation will not need to be changed.

Example response from `tinacms.org/consumers.json`:

```json
{
  "/content/docs/gatsby/configure-git-plugin.md": [
    {
      "file": "/packages/@tinacms/api-git/src/router.ts",
      "details": "Describes GitRouterConfig interface"
    },
    {
      "file": "/packages/gatsby-tinacms-git/gatsby-node.ts",
      "details": "Expects gatsby-tinacms-git to pass options directly to git router"
    }
  ]
}
```