### PR TITLE
add fallback stack, change font-display to fallback

### DIFF
--- a/src/components/foundations/typography/typefaces/fonts.css
+++ b/src/components/foundations/typography/typefaces/fonts.css
@@ -29,11 +29,11 @@
 } */
 
 @font-face {
-	font-family: 'tuner-regular';
-	font-style: normal;
-	font-weight: regular;
-	font-display: swap;
-	src: url('tunerweb-regular.eot') format('embedded-opentype');
-	src: url('tunerweb-regular.eot?#iefix') format('embedded-opentype'),
-				url('tunerweb-regular.woff') format('woff');
+  font-family: 'tuner-regular', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
+    'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-style: normal;
+  font-weight: regular;
+  font-display: fallback;
+  src: url('tunerweb-regular.eot') format('embedded-opentype');
+  src: url('tunerweb-regular.eot?#iefix') format('embedded-opentype'), url('tunerweb-regular.woff') format('woff');
 }


### PR DESCRIPTION
Tuner flashes as the browser default font, so I've added a fallback stack and change `font-display` to `fallback` instead of `swap`