### PR TITLE
Documents remark hook and render props

### DIFF
--- a/content/docs/gatsby/creating-new-files.md
+++ b/content/docs/gatsby/creating-new-files.md
@@ -338,7 +338,7 @@ Head to the template file where you may have a Tina form setup. Read more on set
 import { remarkForm, DeleteAction } from 'gatsby-tinacms-remark'
 
 const BlogTemplateOptions = {
-  actions: [DeleteAction],
+  actions: [ DeleteAction ],
   fields: [
     //...
   ],

--- a/content/docs/gatsby/creating-new-files.md
+++ b/content/docs/gatsby/creating-new-files.md
@@ -8,6 +8,11 @@ consumes:
     details: Demonstrates use of RemarkCreatorPlugin
   - file: /packages/gatsby-tinacms-json/src/create-json-plugin.ts
     details: Demonstrates use of jsonCreatorPlugin
+  - file: /packages/gatsby-tinacms-remark/src/form-actions/delete-action.tsx
+    details: Shows how to add delete action
+  - file: /packages/tinacms/src/components/CreateContent.tsx
+    details: Has image of what the create form looks like
+
 ---
 
 An integral aspect of content management is the ability to create new content. To create new content files with Tina, you will need to configure and register `content-creator` plugins with the cms.

--- a/content/docs/gatsby/markdown.md
+++ b/content/docs/gatsby/markdown.md
@@ -2,6 +2,17 @@
 title: Markdown in Gatsby
 prev: /docs/gatsby/manual-setup
 next: /docs/gatsby/json
+consumes:
+  - file: /packages/gatsby-tinacms-remark/src/RemarkForm.tsx
+    details: Demonstrates use of RemarkForm
+  - file: /packages/gatsby-tinacms-remark/src/remarkFormHoc.tss
+    details: Shows how to use remarkForm HOC
+  - file: /packages/gatsby-tinacms-remark/src/useRemarkForm.tsx
+    details: Demonstrates useRemarkForm usage
+  - file: /packages/gatsby-tinacms-remark/src/remark-fragment.ts
+    details: Explains what the fragment adds
+  - file: /packages/@tinacms/core/src/cms-forms/form.ts
+    details: Explains form options interface
 ---
 
 Gatsby allows you to build sites from many different data sources. Currently Tina has plugins for editing content in [markdown](/docs/gatsby/markdown#editing-markdown-content) & [JSON](/docs/gatsby/json#editing-json-in-gatsby) files, with plans to support many more data sources.

--- a/content/docs/gatsby/markdown.md
+++ b/content/docs/gatsby/markdown.md
@@ -313,7 +313,7 @@ Tina's [remark hook or components](http://tinacms.org/docs/gatsby/markdown#creat
 
 You can pass additional configuration options to customize the form. The following properties are accepted:
 
-- `label`: A optional label for the form that will render in a list if there are multiple forms.
+- `label`: A label for the form that will render in a list if there are multiple forms. This will default to the name of the component.
 - `actions`: A list of form actions, such as [`DeleteAction`](https://tinacms.org/docs/gatsby/creating-new-files#deleting-files).
 - `fields`: A list of field definitions
   - `name`: The path to some value in the data being edited. (e.g. `frontmatter.title`)

--- a/content/docs/gatsby/markdown.md
+++ b/content/docs/gatsby/markdown.md
@@ -17,7 +17,7 @@ The [`gatsby-transformer-remark`](https://github.com/gatsbyjs/gatsby/tree/master
 - `gatsby-tinacms-remark`: Provides hooks and components for creating Remark forms.
 - `gatsby-tinacms-git`: Extends the gatsby development server to write changes to the local filesystem.
 
-### Install the Git & Markdown Packages
+## Install the Git & Markdown Packages
 
     npm install --save gatsby-tinacms-remark gatsby-tinacms-git
 
@@ -25,7 +25,7 @@ or
 
     yarn add gatsby-tinacms-remark gatsby-tinacms-git
 
-### Adding the Git Plugin
+## Adding the Git Plugin
 
 Open the `gatsby-config.js` file and add both plugins:
 
@@ -47,17 +47,183 @@ module.exports = {
 }
 ```
 
-### Creating Remark Forms
+## Creating Remark Forms
 
-The `remarkForm` [higher-order component](https://reactjs.org/docs/higher-order-components.html) (HOC) let's us register forms with `Tina`. In order for it to work with your template, 3 fields must be included in the `markdownRemark` query:
+There are three ways to register remark forms with the CMS, depending on the component:
 
-There are 3 steps to making a markdown file editable:
+- [`useLocalRemarkForm`](http://tinacms.org/docs/gatsby/markdown#1-the-hook-code-classlanguage-textuseremarkformremark-values-formcode) - A [React Hook](https://reactjs.org/docs/hooks-intro.html) — useful for any function component. You can use this with components that source data from a [static query](https://www.gatsbyjs.org/docs/static-query/#how-staticquery-differs-from-page-query) using Gatsby's `useStaticQuery` hook.
+- [`RemarkForm`](http://tinacms.org/docs/gatsby/markdown#2-the-render-props-component-code-classlanguage-textremarkformcode) — A [Render Props](https://reactjs.org/docs/render-props.html#use-render-props-for-cross-cutting-concerns) component — useful for any class component. Can be used with components sourcing data from a [static query](https://www.gatsbyjs.org/docs/static-query/#how-staticquery-differs-from-page-query) using Gatsby's [`StaticQuery`](https://www.gatsbyjs.org/docs/static-query/) render props component.
+- [`remarkForm`](http://tinacms.org/docs/gatsby/markdown#3-the-higher-order-component-code-classlanguage-textremarkformcode) — A [Higher-Order Component](https://reactjs.org/docs/higher-order-components.html) — useful for [page components](https://www.gatsbyjs.org/docs/recipes/#creating-pages-automatically) (function or class), that source data from a [page query](https://www.gatsbyjs.org/docs/page-query/).
+
+All of these options can only take data (transformed by `gatsby-transformer-remark`) from a `markdownRemark` query. If you need more information on using markdown in Gatsby, refer to [this documentation](https://www.gatsbyjs.org/docs/adding-markdown-pages/).
+
+<tip>If you're adding Tina to a page component in Gatsby, skip to [`remarkForm`](http://tinacms.org/docs/gatsby/markdown#3-the-higher-order-component-remarkform).</tip>
+
+### 1. The Hook: useLocalRemarkForm
+
+This hook connects the `markdownRemark` data with Tina to be made editable. It is useful in situations where you need to edit on non-page components, or just prefer working with hooks or static queries. You can also use this hook with functional page components.
+
+#### Usage:
+
+`useLocalRemarkForm(remark, options): [values, form]`
+
+#### Arguments:
+
+- `remark`: The data returned from a Gatsby `markdownRemark` query.
+- `options`: A configuration object that can include [form options](https://tinacms.org/docs/gatsby/markdown#customizing-remark-forms) or form actions (such as the [`DeleteAction`](https://tinacms.org/docs/gatsby/creating-new-files#deleting-files))— optional.
+
+#### Return:
+
+- `[values, form]`
+  - `values`: The current values to render in the template. This has the same shape as the `markdownRemark` data.
+  - `form`: A reference to the `Form`. Most of the time you won't need to directly work with the `Form`.
+
+```javascript
+/*
+** example component --> src/components/Title.js
+*/
+
+// 1. import useLocalRemarkForm
+import { useLocalRemarkForm } from 'gatsby-tinacms-remark'
+import { useStaticQuery } from 'gatsby'
+
+conts Title = (data) => {
+
+  // 2. Add required graphql fragment
+  const data = useStaticQuery(graphql`
+    query TitleQuery {
+      markdownRemark(fields: {slug: {eq: "song-of-myself"}}) {
+        ...TinaRemark
+        frontmatter {
+          title
+        }
+      }
+    }
+  `)
+
+  // 3. Call the hook and pass in the data
+  const [ markdownRemark ] = useLocalRemarkForm(data.markdownRemark)
+
+  return <h1>{markdownRemark.frontmatter.title}</h1>
+}
+
+export default Title
+```
+
+To use this hook, you'll first need to import it from `gatsby-tinacms-remark`. Then you'll need to add the GraphQL fragment `...TinaRemark` to your query. The fragment adds these parameters: `id`, `fileRelativePath`, `rawFrontmatter`, and `rawMarkdownBody`. Finally you'll call the hook and pass in the `markdownRemark` data.
+
+The form will populate with default text fields. To customize it, you can pass in a config options object as the second parameter. Jump ahead to learn more on [customizing the form](http://tinacms.org/docs/gatsby/markdown#customizing-remark-forms).
+
+### 2. The Render Props Component: RemarkForm
+
+`RemarkForm` is a thin wrapper around `useLocalRemarkForm`. Since React [Hooks](https://reactjs.org/docs/hooks-intro.html) are only available within [function components](https://reactjs.org/docs/components-and-props.html) you may need to use `RemarkForm` instead of calling `useLocalRemarkForm` directly when working with a [class component](https://reactjs.org/docs/components-and-props.html).
+
+#### Props:
+
+- `remark`: the data returned from a Gatsby `markdownRemark` query.
+- `render(renderProps): JSX.Element`: A function that returns JSX elements
+  - `renderProps.markdownRemark`: The current values to be displayed. This has the same shape as the `markdownRemark` data that was passed in.
+  - `renderProps.form`: A reference to the [`Form`](http://localhost:8000/docs/concepts/forms/).
+
+You can use this with both page and non-page components in Gatsby. Below is an example of using `RemarkForm` in a non-page component using [`StaticQuery`](https://www.gatsbyjs.org/docs/static-query/).
+
+```javascript
+/*
+** example component --> src/components/Title.js
+*/
+import { StaticQuery, graphql } from 'gatsby'
+
+// 1. import RemarkFrom
+import { RemarkForm } from 'gatsby-tinacms-remark'
+
+class Title extends React.Component {
+  render() {
+    return <StaticQuery
+              // 3. add ...TinaRemark fragment to query
+              query ={graphql`
+                query TitleQuery {
+                  markdownRemark(fields: {slug: {eq: "song-of-myself"}}) {
+                    ...TinaRemark
+                    frontmatter {
+                      title
+                    }
+                  }
+                }
+              `}
+              render = { data => (
+                /*
+                ** 3. Return RemarkForm, pass in the props
+                **    and then return the jsx this component
+                **    should render
+                */
+                <RemarkForm
+                  remark = {data.markdownRemark}
+                  render = {({ markdownRemark }) => {
+                    return <h1>{ markdownRemark.frontmatter.title }</h1>
+                }}
+              />)}
+            />
+  }
+}
+
+export default Title
+```
+Here is another example using `RemarkForm` with a page component:
+
+```js
+/*
+** src/templates/blog-post.js
+*/
+
+// 1. import RemarkForm
+import { RemarkForm } from '@tinacms/gatsby-tinacms-remark'
+
+class BlogPostTemplate extends React.Component {
+  render() {
+    /*
+    ** 2. Return RemarkForm, pass in markdownRemark
+    **    as props and return the jsx this component
+    **    should render
+    */
+    return (
+      <RemarkForm
+        remark={this.props.data.markdownRemark}
+        render={({ markdownRemark }) => {
+          return <h1>{markdownRemark.frontmatter.title}</h1>
+        }}
+      />
+    )
+  }
+}
+
+export default BlogPostTemplate
+
+// 3. Add ...TinaRemark fragment to query
+export const pageQuery = graphql`
+  query {
+    markdownRemark(fields: { slug: { eq: $slug } }) {
+      ...TinaRemark
+      frontmatter {
+        title
+      }
+    }
+  }
+`
+```
+
+Learn how to customize the fields displayed in the form [below](http://tinacms.org/docs/gatsby/markdown#customizing-remark-forms).
+
+### 3. The Higher-Order Component: remarkForm
+
+The `remarkForm` [higher-order component](https://reactjs.org/docs/higher-order-components.html) (HOC) let's us register forms with `Tina` on Gatsby page components.
+
+There are 3 steps to making a markdown file editable with `remarkForm`:
 
 1. Import the `remarkForm` HOC
 2. Wrap your template with `remarkForm`
 3. Add `...TinaRemark` to the GraphQL query
 
-<tip>Required fields used to be queried individually: `id`, `fileRelativePath`, `rawFrontmatter`, & `rawMarkdownBody`. The same fields are now being queried via `TinaRemark`</tip>
+<tip>Required fields used to be queried individually: `id`, `fileRelativePath`, `rawFrontmatter`, & `rawMarkdownBody`. The same fields are now being queried via `...TinaRemark`</tip>
 
 **Example: src/templates/blog-post.js**
 
@@ -89,7 +255,7 @@ export const pageQuery = graphql`
 `
 ```
 
-You should now see text inputs for each of your frontmatter fields and for the markdown body. Try changing the tile and see what happens!
+You should now see text inputs for each of your frontmatter fields and for the markdown body. Try changing the title and see what happens!
 
 ### Queries aliasing 'markdownRemark'
 
@@ -113,7 +279,7 @@ export const pageQuery = graphql`
 `
 ```
 
-### Editing Markdown Content
+## Editing Markdown Content
 
 With the Remark Form created, you can now edit your markdown file in the Tina sidebar. The `markdown` component is [commonmark](https://commonmark.org/help/) compatible. Content changes are written to the markdown files in real time. Hitting `Save` will commit those changes to your repository.
 
@@ -122,9 +288,9 @@ With the Remark Form created, you can now edit your markdown file in the Tina si
 This allows any `gatsby-remark-*` plugins to properly transform the data in to a remark node and
 provide a true-fidelity preview of the changes.
 
-### Customizing Remark Forms
+## Customizing Remark Forms
 
-The `remarkForm` HOC creates the form based on the shape of your data. This is convenient for getting started but you will want to customize the form eventually.
+Tina's [remark hook or components](http://tinacms.org/docs/gatsby/markdown#creating-remark-forms) create the form based on the shape of the data. This is convenient for getting started but you will want to customize the form eventually to make it more user friendly.
 
 **Why customize the form?**
 
@@ -134,8 +300,10 @@ The `remarkForm` HOC creates the form based on the shape of your data. This is c
 
 **How to customize the form**
 
-The `remarkForm` function accepts an optional `config` object for overriding the default configuration of a `RemarkForm`. The following properties are accepted:
+You can pass additional configuration options to customize the form. The following properties are accepted:
 
+- `label`: A optional label for the form that will render in a list if there are multiple forms.
+- `actions`: A list of form actions, such as [`DeleteAction`](https://tinacms.org/docs/gatsby/creating-new-files#deleting-files).
 - `fields`: A list of field definitions
   - `name`: The path to some value in the data being edited. (e.g. `frontmatter.title`)
   - `component`: The name of the React component that should be used to edit this field.
@@ -143,9 +311,15 @@ The `remarkForm` function accepts an optional `config` object for overriding the
   - `label`: A human readable label for the field.
   - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
-#### Example: src/templates/blog-post.js
+### `remarkForm` HOC Example
+
+The `remarkForm` HOC and `useLocalRemarkForm` hook both accept an optional `config` object as the second argument.
 
 ```jsx
+/*
+** src/templates/blog-post.js
+*/
+
 import { remarkForm } from 'gatsby-tinacms-remark'
 
 function BlogPostTemplate(props) {
@@ -157,8 +331,9 @@ function BlogPostTemplate(props) {
   )
 }
 
-// 1. Define the form
-let BlogPostForm = {
+// 1. Define the form config
+const BlogPostForm = {
+  label: 'Blog Post',
   fields: [
     {
       label: 'Title',
@@ -178,3 +353,87 @@ let BlogPostForm = {
 // 2. Pass it as a the second argument to `remarkForm`
 export default remarkForm(BlogPostTemplate, BlogPostForm)
 ```
+
+### `useLocalRemarkForm` Hook Example
+
+```js
+import { useLocalRemarkForm } from 'gatsby-tinacms-remark'
+
+function BlogPostTemplate(props) {
+
+  // 1. Define the form
+  const BlogPostForm = {
+    label: 'Blog Post',
+    fields: [
+      {
+        label: 'Title',
+        name: 'frontmatter.title',
+        description: 'Enter the title of the post here',
+        component: 'text',
+      },
+      {
+        label: 'Description',
+        name: 'frontmatter.description',
+        description: 'Enter the post description',
+        component: 'textarea',
+      },
+    ],
+  }
+
+  // 2. Pass the form as the second argument
+  const [ markdownRemark ] = useLocalRemarkForm(props.markdownRemark, BlogPostForm)
+  return (
+    <>
+      <h1>{markdownRemark.frontmatter.title}</h1>
+      <p>{markdownRemark.frontmatter.description}</p>
+    </>
+  )
+}
+
+export default BlogPostTemplate
+```
+
+### `RemarkForm` Render Props Example
+
+For the `RemarkForm`component, you pass in the config options individually as props to the render function.
+
+```js
+import { RemarkForm } from 'gatsby-tinacms-remark'
+
+class BlogPostTemplate extends React.Component {
+  render() {
+    return (
+      <RemarkForm
+        remark={this.props.data.markdownRemark}
+        render={({ markdownRemark }) => {
+          return (
+            <>
+             <h1>{markdownRemark.frontmatter.title}</h1>
+              <p>{markdownRemark.frontmatter.description}</p>
+            </>
+          )
+        }}
+        label = 'Blog Post'
+        fields = {[
+          {
+            label: 'Title',
+            name: 'frontmatter.title',
+            description: 'Enter the title of the post here',
+            component: 'text',
+          },
+          {
+            label: 'Description',
+            name: 'frontmatter.description',
+            description: 'Enter the post description',
+            component: 'textarea',
+          },
+        ]}
+      />
+    )
+  }
+}
+
+export default BlogPostTemplate
+```
+
+

--- a/content/docs/gatsby/markdown.md
+++ b/content/docs/gatsby/markdown.md
@@ -139,7 +139,7 @@ import { RemarkForm } from 'gatsby-tinacms-remark'
 class Title extends React.Component {
   render() {
     return <StaticQuery
-              // 3. add ...TinaRemark fragment to query
+              // 2. add ...TinaRemark fragment to query
               query ={graphql`
                 query TitleQuery {
                   markdownRemark(fields: {slug: {eq: "song-of-myself"}}) {


### PR DESCRIPTION
Closes #112 

- Adds documentation on `useLocalRemarkForm`, `RemarkForm` render props component. 

You can read the updated doc by going to docs > Tina + Gatsby > Using Markdown Files in the PR preview