### PR TITLE
Fix docs landing

### DIFF
--- a/content/docs/getting-started/introduction.md
+++ b/content/docs/getting-started/introduction.md
@@ -25,15 +25,7 @@ To use Tina, you should have a good working knowledge of your JavaScript framewo
 
 If you want to get started with some code right away, checkout the [Gatsby Quickstart](/docs/gatsby/quickstart) or [Next.js Overview](/docs/nextjs/overview).
 
-## Core Concepts
-
 If you want to dive deep, start by learning more about [how Tina works](/docs/getting-started/how-tina-works) and get familiar with some core concepts.
-
- - [Sidebar](/docs/concepts/sidebar)
- - [Forms](/docs/concepts/forms)
- - [Fields](/docs/concepts/fields)
- - [Backends](/docs/concepts/backends)
- - [Plugins](/docs/concepts/plugins)
 
 ## For Gatsby
 

--- a/content/docs/getting-started/introduction.md
+++ b/content/docs/getting-started/introduction.md
@@ -23,9 +23,35 @@ Tina currently supports React-based frameworks, including:
 
 To use Tina, you should have a good working knowledge of your JavaScript framework & JAMstack tools of choice.
 
-To get a better idea of what Tina is all about, take a look at [how Tina works](/docs/getting-started/how-tina-works 'How Tina Works').
+If you want to get started with some code right away, checkout the [Gatsby Quickstart](/docs/gatsby/quickstart) or [Next.js Overview](/docs/nextjs/overview).
 
-If you're itching to see what Tina can do, head over to the [Gatsby Quickstart Guide](/docs/gatsby/quickstart) to get up and running fast.
+## Core Concepts
+
+If you want to dive deep, start by learning more about [how Tina works](/docs/getting-started/how-tina-works) and get familiar with some core concepts.
+
+ - [Sidebar](/docs/concepts/sidebar)
+ - [Forms](/docs/concepts/forms)
+ - [Fields](/docs/concepts/fields)
+ - [Backends](/docs/concepts/backends)
+ - [Plugins](/docs/concepts/plugins)
+
+## For Gatsby
+
+- [Quickstart](/docs/gatsby/quickstart) with a Tina Starter to hit the ground running.
+- [Manual Setup](/docs/gatsby/manual-setup) for adding Tina to an existing Gatsby site.
+
+**Gatsby Starters**
+- [Gatsby Blog Starter](https://github.com/tinacms/gatsby-starter-tinacms) with Tina — The classic Gatsby starter, but Tinified.
+- [Tina Grande](https://github.com/tinacms/tina-starter-grande) — A more advanced starter to showcase the power of Tina.
+- [Tina Brevifolia](https://github.com/kendallstrautman/brevifolia-gatsby-tinacms) — A markdown-based blog with minimalist design and Tina for editing.
+
+Want to add your starter? Make a [PR](/docs/contributing/guidelines) to add your Tina site to this list.
+
+## For Next.js
+
+- [Next.js + Tina Overview](/docs/nextjs/overview) — Get started with the documentation
+- Read an in-depth tutorial on [Using TinaCMS with Next.js](/blog/using-tinacms-with-nextjs/)
+- Checkout this sample [Next.js Markdown Blog](https://github.com/kendallstrautman/brevifolia-next-tinacms) with Tina configured for reference.
 
 ## Get Involved
 

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -23,22 +23,16 @@ Tina currently supports React-based frameworks, including:
 
 To use Tina, you should have a good working knowledge of your JavaScript framework & JAMstack tools of choice.
 
-If you want to dive deep, start by learning more about [how Tina works](/docs/getting-started/how-tina-works) and get familiar with some core concepts. If you want to get started with some code right away, checkout the Gatsby or Next.js starters below.
+If you want to get started with some code right away, checkout the [Gatsby Quickstart](/docs/gatsby/quickstart) or [Next.js Overview](/docs/nextjs/overview).
 
-## Core Concepts
- - [Sidebar](/docs/concepts/sidebar)
- - [Forms](/docs/concepts/forms)
- - [Fields](/docs/concepts/fields)
- - [Backends](/docs/concepts/backends)
- - [Plugins](/docs/concepts/plugins)
+If you want to dive deep, start by learning more about [how Tina works](/docs/getting-started/how-tina-works) and get familiar with some core concepts.
 
 ## For Gatsby
 
-- [Quickstart](/docs/gatsby/quickstart) with a Tina Starter
-- [Manual Setup](/docs/gatsby/manual-setup) for an existing site
+- [Quickstart](/docs/gatsby/quickstart) with a Tina Starter to hit the ground running.
+- [Manual Setup](/docs/gatsby/manual-setup) for adding Tina to an existing Gatsby site.
 
-#### Gatsby Starters
-
+**Gatsby Starters**
 - [Gatsby Blog Starter](https://github.com/tinacms/gatsby-starter-tinacms) with Tina — The classic Gatsby starter, but Tinified.
 - [Tina Grande](https://github.com/tinacms/tina-starter-grande) — A more advanced starter to showcase the power of Tina.
 - [Tina Brevifolia](https://github.com/kendallstrautman/brevifolia-gatsby-tinacms) — A markdown-based blog with minimalist design and Tina for editing.
@@ -48,8 +42,8 @@ Want to add your starter? Make a [PR](/docs/contributing/guidelines) to add your
 ## For Next.js
 
 - [Next.js + Tina Overview](/docs/nextjs/overview) — Get started with the documentation
-- [Blog: Using TinaCMS with Next.js](/blog/using-tinacms-with-nextjs/)
-- A sample [Next.js Markdown Blog](https://github.com/kendallstrautman/brevifolia-next-tinacms) with Tina configured for reference
+- Read an in-depth tutorial on [Using TinaCMS with Next.js](/blog/using-tinacms-with-nextjs/)
+- Checkout this sample [Next.js Markdown Blog](https://github.com/kendallstrautman/brevifolia-next-tinacms) with Tina configured for reference.
 
 ## Get Involved
 

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,37 +1,58 @@
 ---
-title: Tina Docs
-id: index
+title: Tina is Not a CMS
+id: introduction
 prev: null
-next: /getting-started/installation
+next: /docs/getting-started/how-tina-works
 ---
 
-Tina is a lightweight but powerful toolkit for creating a site editing ui with javascript components. Tina surfaces superpowers for dev's to create, expand on and customize a simple yet intuitive ui for editing content.
+Tina is a **lightweight but powerful toolkit** for creating a content editing interface with JavaScript components. Tina surfaces superpowers for developers to create an intuitive UI for real-time content editing, built directly into their website.
 
-Tina is optimized for nextgen JAMstack tools. It is based in javascript and is extensible enough to be configured with many different frameworks. Right now we have explored using Tina with Gatsby, Create-React-App & Next.js, with plans to dive into Vue.
+## The Next Generation of Content Management
 
-![tina-gif](/img/temporary_show_tina.gif)
+![tina-gif](https://res.cloudinary.com/forestry-demo/video/upload/du_16,w_700,e_loop/v1571159974/tina-hero-demo.gif)
+
+Tina is optimized for next-gen JAMstack tools. It is written in JavaScript and easily adapted to multiple different frameworks.
+
+Tina currently supports React-based frameworks, including:
+
+- Create-React-App
+- Gatsby
+- NextJS
 
 ## Get Started
 
-Depending on your tools, there are a few different flows mapped out for using Tina with either your existing project or to play around on a starter
+To use Tina, you should have a good working knowledge of your JavaScript framework & JAMstack tools of choice.
 
-#### With Gatsby
+If you want to dive deep, start by learning more about [how Tina works](/docs/getting-started/how-tina-works) and get familiar with some core concepts. If you want to get started with some code right away, checkout the Gatsby or Next.js starters below.
 
-1. [Use the starter](/docs/gatsby/quickstart)
-2. [Add to existing site](gatsby/manual-setup)
+## Core Concepts
+ - [Sidebar](/docs/concepts/sidebar)
+ - [Forms](/docs/concepts/forms)
+ - [Fields](/docs/concepts/fields)
+ - [Backends](/docs/concepts/backends)
+ - [Plugins](/docs/concepts/plugins)
 
-#### With Create-React-App
+## For Gatsby
 
-_Coming soon_
+- [Quickstart](/docs/gatsby/quickstart) with a Tina Starter
+- [Manual Setup](/docs/gatsby/manual-setup) for an existing site
 
-#### With Next.js
+#### Gatsby Starters
 
-_Coming soon_
+- [Gatsby Blog Starter](https://github.com/tinacms/gatsby-starter-tinacms) with Tina — The classic Gatsby starter, but Tinified.
+- [Tina Grande](https://github.com/tinacms/tina-starter-grande) — A more advanced starter to showcase the power of Tina.
+- [Tina Brevifolia](https://github.com/kendallstrautman/brevifolia-gatsby-tinacms) — A markdown-based blog with minimalist design and Tina for editing.
 
-## Contributing
+Want to add your starter? Make a [PR](/docs/contributing/guidelines) to add your Tina site to this list.
 
-Want to get involved? Please visit our [Contributing]() section in our docs to learn more and get help with troubleshooting.
+## For Next.js
 
-## About
+- [Next.js + Tina Overview](/docs/nextjs/overview) — Get started with the documentation
+- [Blog: Using TinaCMS with Next.js](/blog/using-tinacms-with-nextjs/)
+- A sample [Next.js Markdown Blog](https://github.com/kendallstrautman/brevifolia-next-tinacms) with Tina configured for reference
 
-Tina started as a side project for some engineers at [Forestry.io](https://forestry.io/), what was a cool idea has turned into this site editing schema that could change the way content is edited on the web. Our vision is to...
+## Get Involved
+
+Want to help out with Tina's development? Please visit our [Contributing](/docs/contributing/guidelines) section in our docs to learn more.
+
+Looking for help with Tina, or want to stay on top of the latest developments? Checkout the [Tina Community Forum](https://community.tinacms.org/) to get answers, help, and llama-humor.

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -25,12 +25,7 @@ const DocsTemplate = ({ data, setIsEditing, isEditing }) => {
   const prevPage = getPageById(sectionList.edges, prev)
   const nextPage = getPageById(sectionList.edges, next)
   const sidebar = useSidebar()
-  useEffect(() => {
-    //redirect away from index.md since the introduction doc is main for now
-    if (data.markdownRemark.fileRelativePath === '/content/docs/index.md') {
-      navigate('/docs/getting-started/introduction')
-    }
-  }, [])
+
   return (
     <DocsLayout sidebarNav={sectionList}>
       <Page docsPage>


### PR DESCRIPTION
fixes #183 
fixes #182 

Removed the redirect for `/docs` and updated the index file. We should think more on how we want to structure the flow for the home docs page to these other intro / learning path files. Right now the nav still goes to `/docs/getting-started/introduction` and that content is the same as `/docs`, but in the future we could make a better `/docs` landing page, remove or improve that introduction file and rethink the process of how we start people off when they hit the docs.