### PR TITLE
Use theme variables to determine docs sidebar width

### DIFF
--- a/src/components/layout/Navigation/DocsNavigation.tsx
+++ b/src/components/layout/Navigation/DocsNavigation.tsx
@@ -70,7 +70,7 @@ const WrapperInner = styled('nav')`
   }
 
   @media (min-width: ${breakpoints.lg}px) {
-    width: 225px;
+    width: ${dimensions.widths.sidebar.lg}px;
     flex: 1 1 auto;
     z-index: 2;
     overflow-y: auto;

--- a/src/components/layout/Navigation/Navigation.tsx
+++ b/src/components/layout/Navigation/Navigation.tsx
@@ -62,7 +62,7 @@ const WrapperInner = styled('nav')`
   margin-top: ${dimensions.heights.header}px;
 
   @media (min-width: ${breakpoints.lg}px) {
-    width: 200px;
+    width: ${dimensions.widths.sidebar.lg}px;
     overflow: none;
   }
 `

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -12,7 +12,7 @@ export const colors = {
   lightPurple: '#302454',
   darkPurple: '#241748',
   grey: '#595959',
-  darkGrey: "#404040",
+  darkGrey: '#404040',
 
   // Blue
   /** Blue01 - Glitter */
@@ -351,7 +351,7 @@ export const dimensions = {
     sidebar: {
       sm: 240,
       md: 280,
-      lg: 200,
+      lg: 225,
     },
     containerPadding: space.lg,
   },


### PR DESCRIPTION
Uses the proper theme variables to determine sidebar with. This prevents
the overlapping of `DocsNavigation` and `DocsLayoutMain`.

![image](https://user-images.githubusercontent.com/5663877/71249927-ea17b700-2350-11ea-80d8-125b5953ac89.png)
