### PR TITLE
Adds @tinacms/styles docs

### DIFF
--- a/content/docs/concepts/sidebar.md
+++ b/content/docs/concepts/sidebar.md
@@ -222,22 +222,22 @@ const DefaultTheme = {
     },
   },
   radius: {
-    small: '0.3rem',
-    big: '1.5rem',
+    small: '5px',
+    big: '24px',
   },
   padding: {
-    small: '0.75rem',
-    big: '1.25rem',
+    small: '12px',
+    big: '20px',
   },
   font: {
     size: {
-      0: '0.6875rem', // 11px
-      1: '0.8125rem', // 13px
-      2: '0.9375rem', // 15px
-      3: '1rem', // 16px
-      4: '1.125rem', // 18px
-      5: '1.25rem', // 20px
-      6: '1.375rem', // 22px
+      0: '11px',
+      1: '13px',
+      2: '15px',
+      3: '16px',
+      4: '18px',
+      5: '20px',
+      6: '22px',
     },
     weight: {
       regular: 500,

--- a/content/docs/concepts/sidebar.md
+++ b/content/docs/concepts/sidebar.md
@@ -9,7 +9,7 @@ consumes:
   - file: /packages/tinacms/src/components/Tina.tsx
     details: Explains hiding sidebar in prod
   - file: /packages/@tinacms/styles/src/Styles.tsx
-    details: Shows the Theme interface
+    details: Shows the Theme interface and Default Theme values
 ---
 
 The **sidebar** is the primary interface in Tina. It is the shell that holds [forms](/docs/concepts/forms 'Tina Concepts: Forms') and [plugins](/docs/concepts/plugins 'Tina Concepts: Plugins').
@@ -87,9 +87,9 @@ class MyApp extends App {
   }
   // Sidebar options
   options = {
-      sidebar: {
-        hidden: process.env.NODE_ENV === "production"
-      }
+    sidebar: {
+      hidden: process.env.NODE_ENV === "production"
+    }
   }
   render() {
     const { Component, pageProps } = this.props
@@ -112,8 +112,6 @@ We want you to be able to mold Tina to fit your use-case, including the styling 
 ``` javascript
 // gatsby-config.js
 
-const theme = require("./content/settings/theme.json")
-
 {
   resolve: 'gatsby-plugin-tinacms',
   options: {
@@ -121,9 +119,9 @@ const theme = require("./content/settings/theme.json")
       theme: {
         color: {
           primary: {
-            light: theme.color.primary,
-            medium: theme.color.primary,
-            dark: theme.color.primary,
+            light: #E6FAF8,
+            medium: #EC4815,
+            dark: #241748,
           },
         },
       },
@@ -131,7 +129,7 @@ const theme = require("./content/settings/theme.json")
   },
 }
 ```
-
+### Theme Options
 Below is the interface for the Tina Theme — all the properties to play with.
 
 ``` typescript
@@ -194,3 +192,66 @@ interface Theme {
   }
 }
 ```
+### Default Theme
+If no theme options are passed, these are the default values:
+
+```js
+const DefaultTheme = {
+  color: {
+    primary: {
+      light: '#2296FE',
+      medium: '#0084ff',
+      dark: '#0574E4',
+    },
+    error: {
+      light: '#EB6337',
+      medium: '#EC4815',
+      dark: '#DC4419',
+    },
+    grey: {
+      0: '#FFFFFF',
+      1: '#F6F6F9',
+      2: '#EDECF3',
+      3: '#E1DDEC',
+      4: '#B2ADBE',
+      5: '#918C9E',
+      6: '#716C7F',
+      7: '#565165',
+      8: '#433E52',
+      9: '#363145',
+    },
+  },
+  radius: {
+    small: '0.3rem',
+    big: '1.5rem',
+  },
+  padding: {
+    small: '0.75rem',
+    big: '1.25rem',
+  },
+  font: {
+    size: {
+      0: '0.6875rem', // 11px
+      1: '0.8125rem', // 13px
+      2: '0.9375rem', // 15px
+      3: '1rem', // 16px
+      4: '1.125rem', // 18px
+      5: '1.25rem', // 20px
+      6: '1.375rem', // 22px
+    },
+    weight: {
+      regular: 500,
+      bold: 600,
+    },
+  },
+  shadow: {
+    small: '0px 2px 3px rgba(0, 0, 0, 0.12)',
+    big: '0px 2px 3px rgba(0, 0, 0, 0.12), 0px 4px 8px rgba(48, 48, 48, 0.1)',
+  },
+  timing: {
+    short: '85ms',
+    medium: '150ms',
+    long: '250ms',
+  },
+```
+You can import this `DefaultTheme` from `@tinacms/styles` to utilize theme values in your styles. This can be especially helpful when [making custom fields](https://tinacms.org/docs/fields/custom-fields). Read more on [using Tina styles with custom fields](/docs/fields/custom-fields#using-tina-styles).

--- a/content/docs/fields/custom-fields.md
+++ b/content/docs/fields/custom-fields.md
@@ -103,6 +103,82 @@ cms.fields.add({
 })
 ```
 
+## Using Tina Styles
+
+If you want to style the custom field to fit in with the rest of the Tina sidebar, you'll need to access Tina theme styles from [`@tinacms/styles`](https://github.com/tinacms/tinacms/blob/master/packages/%40tinacms/styles/src/Styles.tsx).
+
+If the Tina theme has been [customized](https://tinacms.org/docs/concepts/sidebar#customizing-the-sidebar-theme), the `Theme` values will be a combination of the customized styles and those set by [`DefaultTheme`](https://tinacms.org/docs/concepts/sidebar#default-theme). The theme will fallback to all default values if no customization is set.
+
+To utilize these `Theme` values, helper functions have been created.
+
+### Helper Functions
+<tip>The helpers will only work when using [`styled-components`](https://styled-components.com/) to style custom fields. If using another _CSS-in-JS_ framework, use the [`DefaultTheme` object directly](https://tinacms.org/docs/fields/custom-fields#using-the-default-theme).</tip>
+
+| Color                                                | Default Value |
+| ---------------------------------------------------- | ------------- |
+| `primary(value?: "light" | "medium" | "dark")`       | "medium"      |
+| `grey(value?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9)`| 0             |
+| `error(value?: "light" | "medium" | "dark")`         | "medium"      |
+
+| Font                                                 | Default Value  |
+| ---------------------------------------------------- | -------------- |
+| `size(value?: 0 | 1 | 2 | 3 | 4 | 5 | 6)`            | 0              |
+| `weight(value?: "regular" | "bold")`                 | "regular"      |
+
+| Misc                                                 | Default        | Notes                |
+| ---------------------------------------------------- | -------------- |----------------------|
+| `radius(size?: "small" | "big")`                     | "big"          | For `border-radius`  |
+| `padding(size?: "small" | "big")`                    | "big"          |                      |
+| `shadow(size?: "small" | "big")`                     | "big"          | For `box-shadow`     |
+| `timing(length: "medium" | "short" | "long")`        | `length` req.  | For `transition`     |
+
+```jsx
+/*
+** Example: Helper functions used
+** within a styled component that will
+** render in a custom field
+*/
+
+// 1. Import the helpers
+import { padding, color, radius, font } from "@tinacms/styles"
+import styled from "styled-components"
+
+// 2. Use the helpers in your styled components
+const Label = styled.h3`
+  color: ${color.primary()};
+  font-size: ${font.size(3)};
+  font-weight: ${font.weight("bold")};
+  border-radius: ${radius()};
+  border: 1px solid ${color.primary("light")};
+  transition: color linear ease ${timing("medium")};
+  padding: ${padding("small")};
+`
+```
+
+### Using the Default Theme
+
+You can also access the [`DefaultTheme`](https://tinacms.org/docs/concepts/sidebar#default-theme) directly without using the helpers. This is helpful when you want to utilize Tina Theme styles outside of `styled-components` or if you just prefer working with the theme values directly, without helpers.
+
+<tip>Although it's called `DefaultTheme`, note that if you pass [custom values to the sidebar](https://tinacms.org/docs/concepts/sidebar#customizing-the-sidebar-theme), `DefaultTheme` provides the overridden values instead of the true Tina defaults.</tip>
+
+```jsx
+/*
+** Example: Using `DefaultTheme`
+** directly with a CSS-in-JS,
+** framework `styled-jsx`
+*/
+
+// 1. Import `DefaultTheme`
+import { DefaultTheme } from "@tinacms/styles"
+
+//2. Use `DefaultTheme` values in your styles
+<style jsx>{`
+  label {
+    color: ${DefaultTheme.color.primary.medium};
+  }
+`}</style>
+```
+
 ## Further Reading
 
 - [Registering Fields in Gatsby](/docs/gatsby/custom-fields)


### PR DESCRIPTION
Closes #211 - Adds more info on the `DefaultTheme` values and direction on how to use both the helpers and the `DefaultTheme` directly when styling custom components. 