### PR TITLE
docs: updating next docs to reference using default key

### DIFF
--- a/content/blog/simple-markdown-blog-nextjs.md
+++ b/content/blog/simple-markdown-blog-nextjs.md
@@ -72,7 +72,7 @@ export default Index
 Index.getInitialProps = async function() {
   const configData = await import(`../data/config.json`)
   return {
-    ...configData,
+    ...configData.default,
   }
 }
 ```
@@ -241,7 +241,7 @@ Index.getInitialProps = async function() {
 
   return {
     allBlogs: posts,
-    ...siteConfig,
+    ...siteConfig.default,
   }
 }
 ```

--- a/content/docs/nextjs/creating-forms.md
+++ b/content/docs/nextjs/creating-forms.md
@@ -34,7 +34,7 @@ Page.getInitialProps = function(ctx) {
   return {
     post: {
       fileRelativePath: `/posts/${slug}.json`,
-      data: content,
+      data: content.default,
     },
   }
 }
@@ -85,7 +85,7 @@ Since the object we're returning from `getInitialProps` already matches the `Jso
    return {
      post: {
        fileRelativePath: `/posts/${slug}.json`,
-       data: content,
+       data: content.default,
      },
    }
  }


### PR DESCRIPTION
Resolving #233 

All I did was attempt to reference anywhere json was being imported in getInitialProps to use the default key. It didn't feel super necessary to specify beyond that, but happy to update if there are guidelines on how the docs are trying to be moved forward and something you feel is missing :)

Thanks!